### PR TITLE
Fix/add test for to hex #15

### DIFF
--- a/api_endpoint/src/utils.rs
+++ b/api_endpoint/src/utils.rs
@@ -26,10 +26,64 @@ pub fn get_specific_error(code: StatusCode, error: String) -> Response {
 
 pub fn to_hex(felt: FieldElement) -> String {
     let bytes = felt.to_bytes_be();
+    
+    if bytes.iter().all(|&b| b == 0) {
+        return String::from("0x0");
+    }
+
+    let non_zero_bytes = bytes.iter().skip_while(|&&b| b == 0);
+
     let mut result = String::with_capacity(bytes.len() * 2 + 2);
     result.push_str("0x");
-    for byte in bytes {
+    for &byte in non_zero_bytes {
         write!(&mut result, "{:02x}", byte).unwrap();
     }
+    
     result
+}
+
+#[cfg(test)]
+mod mytests{
+    use starknet::core::types::FieldElement;
+    use super::to_hex;
+
+    #[test]
+    fn test_to_hex_small_number() {
+        let num = FieldElement::from(255u64);
+        assert_eq!(to_hex(num), "0xff");
+    }
+
+    #[test]
+    fn test_to_hex_large_number() {
+        let num = FieldElement::from(1234567890u64);
+        assert_eq!(to_hex(num), "0x499602d2");
+    }
+
+    #[test]
+    fn test_single_digit() {
+        let num = FieldElement::from(10u64);
+        assert_eq!(to_hex(num), "0x0a");
+    }
+
+    #[test]
+    fn test_boundary_values() {
+        let cases = [
+            (u64::MAX, "0xffffffffffffffff"),
+            (u64::MIN, "0x0"),
+            (u32::MAX as u64, "0xffffffff"),
+        ];
+
+        for (input, expected) in cases {
+            let num = FieldElement::from(input);
+            assert_eq!(to_hex(num), expected);
+        }
+    }
+
+    #[test]
+    fn test_to_hex_max() {
+        let max = FieldElement::MAX;
+        assert_eq!(to_hex(max).len(), 66);
+        assert!(to_hex(max).starts_with("0x"));
+    }
+
 }


### PR DESCRIPTION
Added test cases and modified the ```to_hex``` function to ensure it gives the required output in testing scenarios. Here is a detailed description for the changes in ```to_hex``` function.


## Changes to hex_function

1. returns 0x0 when all bytes are zero.

```rust
if bytes.iter().all(|&b| b == 0) {
        return String::from("0x0");
    }
```
2. skips leading zeros and stats iteration from first non-zero byte.
```rust
let non_zero_bytes = bytes.iter().skip_while(|&&b| b == 0);
```
3. small change that skips leading zero bytes using non_zero_bytes

```rust
for &byte in non_zero_bytes {
    write!(&mut result, "{:02x}", byte).unwrap();
}
```

The given implementation in to_hex function makes sure it passes all test cases.

