### PR TITLE
fixed compilation errors and added test cases for sale_actions

### DIFF
--- a/api_endpoint/src/utils.rs
+++ b/api_endpoint/src/utils.rs
@@ -26,7 +26,7 @@ pub fn get_specific_error(code: StatusCode, error: String) -> Response {
 
 pub fn to_hex(felt: FieldElement) -> String {
     let bytes = felt.to_bytes_be();
-    
+
     if bytes.iter().all(|&b| b == 0) {
         return String::from("0x0");
     }
@@ -38,14 +38,14 @@ pub fn to_hex(felt: FieldElement) -> String {
     for &byte in non_zero_bytes {
         write!(&mut result, "{:02x}", byte).unwrap();
     }
-    
+
     result
 }
 
 #[cfg(test)]
-mod mytests{
-    use starknet::core::types::FieldElement;
+mod utils_tests {
     use super::to_hex;
+    use starknet::core::types::FieldElement;
 
     #[test]
     fn test_to_hex_small_number() {
@@ -85,5 +85,4 @@ mod mytests{
         assert_eq!(to_hex(max).len(), 66);
         assert!(to_hex(max).starts_with("0x"));
     }
-
 }

--- a/sale_actions/src/processing/purchases.rs
+++ b/sale_actions/src/processing/purchases.rs
@@ -243,8 +243,6 @@ pub async fn process_data(conf: &Config, db: &Database, logger: &Logger) {
             processed
                 .iter()
                 .map(|tx_hash| doc! { "meta_hash": tx_hash })
-
-
                 .collect::<Vec<Document>>(),
             None,
         )

--- a/sale_actions/src/processing/purchases.rs
+++ b/sale_actions/src/processing/purchases.rs
@@ -217,7 +217,7 @@ pub async fn process_data(conf: &Config, db: &Database, logger: &Logger) {
                     logger.severe(format!("Error parsing doc in purchase: {}", e));
                 }
                 Ok(sales_doc) => {
-                    processed.push(sales_doc.);
+                    processed.push(sales_doc.tx_hash.clone());
                     batch.push(sales_doc);
                     if batch.len() >= batch_size {
                         process_batch(&conf, &logger, &batch).await;
@@ -242,7 +242,9 @@ pub async fn process_data(conf: &Config, db: &Database, logger: &Logger) {
         .insert_many(
             processed
                 .iter()
-                .map(|meta_hash| doc! { "meta_hash": meta_hash })
+                .map(|tx_hash| doc! { "meta_hash": tx_hash })
+
+
                 .collect::<Vec<Document>>(),
             None,
         )

--- a/sale_actions/src/processing/renewal.rs
+++ b/sale_actions/src/processing/renewal.rs
@@ -273,7 +273,7 @@ pub async fn process_data(conf: &Config, db: &Database, logger: &Logger) {
         .insert_many(
             processed
                 .iter()
-                .map(|tx_hash| doc! { "tx_hash": tx_hash })
+                .map(|tx_hash: &String| doc! { "tx_hash": tx_hash })
                 .collect::<Vec<Document>>(),
             None,
         )

--- a/sale_actions/src/utils.rs
+++ b/sale_actions/src/utils.rs
@@ -13,10 +13,63 @@ macro_rules! pub_struct {
 
 pub fn to_hex(felt: FieldElement) -> String {
     let bytes = felt.to_bytes_be();
+    
+    if bytes.iter().all(|&b| b == 0) {
+        return String::from("0x0");
+    }
+
+    let non_zero_bytes = bytes.iter().skip_while(|&&b| b == 0);
+
     let mut result = String::with_capacity(bytes.len() * 2 + 2);
     result.push_str("0x");
-    for byte in bytes {
+    for &byte in non_zero_bytes {
         write!(&mut result, "{:02x}", byte).unwrap();
     }
+    
     result
+}
+
+mod mytests{
+    use starknet::core::types::FieldElement;
+    use super::to_hex;
+
+    #[test]
+    fn test_to_hex_small_number() {
+        let num = FieldElement::from(255u64);
+        assert_eq!(to_hex(num), "0xff");
+    }
+
+    #[test]
+    fn test_to_hex_large_number() {
+        let num = FieldElement::from(1234567890u64);
+        assert_eq!(to_hex(num), "0x499602d2");
+    }
+
+    #[test]
+    fn test_single_digit() {
+        let num = FieldElement::from(10u64);
+        assert_eq!(to_hex(num), "0x0a");
+    }
+
+    #[test]
+    fn test_boundary_values() {
+        let cases = [
+            (u64::MAX, "0xffffffffffffffff"),
+            (u64::MIN, "0x0"),
+            (u32::MAX as u64, "0xffffffff"),
+        ];
+
+        for (input, expected) in cases {
+            let num = FieldElement::from(input);
+            assert_eq!(to_hex(num), expected);
+        }
+    }
+
+    #[test]
+    fn test_to_hex_max() {
+        let max = FieldElement::MAX;
+        assert_eq!(to_hex(max).len(), 66);
+        assert!(to_hex(max).starts_with("0x"));
+    }
+
 }

--- a/sale_actions/src/utils.rs
+++ b/sale_actions/src/utils.rs
@@ -13,7 +13,7 @@ macro_rules! pub_struct {
 
 pub fn to_hex(felt: FieldElement) -> String {
     let bytes = felt.to_bytes_be();
-    
+
     if bytes.iter().all(|&b| b == 0) {
         return String::from("0x0");
     }
@@ -25,13 +25,13 @@ pub fn to_hex(felt: FieldElement) -> String {
     for &byte in non_zero_bytes {
         write!(&mut result, "{:02x}", byte).unwrap();
     }
-    
+
     result
 }
 
-mod mytests{
-    use starknet::core::types::FieldElement;
+mod utils_tests {
     use super::to_hex;
+    use starknet::core::types::FieldElement;
 
     #[test]
     fn test_to_hex_small_number() {
@@ -71,5 +71,4 @@ mod mytests{
         assert_eq!(to_hex(max).len(), 66);
         assert!(to_hex(max).starts_with("0x"));
     }
-
 }


### PR DESCRIPTION
fixed compilation erros in ```purchases.rs```
```rust
.map(|meta_hash| doc! { "meta_hash": meta_hash })
```
fixed token error by adding ```tx_hash```
```rust
processed.push(sales_doc.tx_hash.clone());
```

fixed type error in ```renewal.rs```
```rust
.map(|tx_hash: &String| doc! { "tx_hash": tx_hash })
```
and added test cases as was asked previously to ```to_hex```